### PR TITLE
Added spring test dependancy to the pom file and updated AdminController test

### DIFF
--- a/project/api/thu-excursion/pom.xml
+++ b/project/api/thu-excursion/pom.xml
@@ -59,6 +59,11 @@
     <version>5.5.3</version>
     <scope>test</scope>
 </dependency>
+<dependency> <!--swagger UI dependancy-->
+    <groupId>org.springdoc</groupId>
+    <artifactId>springdoc-openapi-ui</artifactId>
+    <version>1.5.2</version>
+</dependency>
 	</dependencies>
 
 	<build>

--- a/project/api/thu-excursion/pom.xml
+++ b/project/api/thu-excursion/pom.xml
@@ -47,6 +47,18 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>3.0.0</version> <!--TODO Vulnerability raised by this dependancy: Solution to be researched-->
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.security/spring-security-test -->
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-test</artifactId>
+    <version>5.5.3</version>
+    <scope>test</scope>
+</dependency>
 	</dependencies>
 
 	<build>

--- a/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
+++ b/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
@@ -1,5 +1,6 @@
 package com.thuexcursion.crud;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,14 +13,17 @@ import com.thuexcursion.crud.controller.AdminController;
 import com.thuexcursion.crud.model.Admin;
 import com.thuexcursion.crud.service.AdminService;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest({AdminController.class})
@@ -32,8 +36,6 @@ public class AdminControllerLayerTest {
     AdminService adminService;
 
     /**
-     * This test is currently disabled since POST requests aren't being done at the moment.
-     * 
      * This tests whether a new Admin can successfully be saved with an HTTP Status 200 (OK). 
      * @throws Exception
      */
@@ -43,16 +45,16 @@ public class AdminControllerLayerTest {
 
         Admin admin = new Admin(1, 123, "Max", "Mann", "mann@gmx.de", "Olgastr. 2", "username1", "password1");
 
-        //when(adminService.updateAdmin(any())).thenReturn(Boolean.TRUE);
+        when(adminService.saveAdmin(admin)).thenReturn(admin);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/admin/saveAdmins")
+        RequestBuilder requestBuilder = 
+                MockMvcRequestBuilders.post("/addAdmin")
                         .content(asJsonString(admin))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)
-        )
-                .andExpect(status().isOk())
-                .andExpect(content().string("Admin update complete"));
+                        .accept(MediaType.APPLICATION_JSON);
+                MvcResult result = mockMvc.perform(requestBuilder).andReturn();
+                MockHttpServletResponse response = result.getResponse();
+                assertEquals(HttpStatus.OK.value(),response.getStatus());
     }
 
     /**

--- a/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
+++ b/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
@@ -1,0 +1,95 @@
+package com.thuexcursion.crud;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thuexcursion.crud.controller.AdminController;
+import com.thuexcursion.crud.model.Admin;
+import com.thuexcursion.crud.service.AdminService;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@WebMvcTest({AdminController.class})
+public class AdminControllerLayerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    AdminService adminService;
+
+    /**
+     * This test is currently disabled since POST requests aren't being done at the moment.
+     * 
+     * This tests whether a new Admin can successfully be saved with an HTTP Status 200 (OK).
+     * 
+     * Actual results of the test are 405 Method Not Allowed:
+     * The HyperText Transfer Protocol (HTTP) 405 Method Not Allowed response status code indicates 
+     * that the request method is known by the server but is not supported by the target resource.
+     * The server must generate an Allow header field in a 405 response containing a list of the 
+     * target resource's currently supported methods.
+     * 
+     * @throws Exception
+     */
+    @Disabled
+    @Test
+    @WithMockUser(username = "user1", password = "pwd", roles = "USER")
+    public void testSaveAdmin() throws Exception {
+
+        Admin admin = new Admin(1, 123, "Max", "Mann", "mann@gmx.de", "Olgastr. 2", "username1", "password1");
+
+        //when(adminService.updateAdmin(any())).thenReturn(Boolean.TRUE);
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.post("/admin/saveAdmins")
+                        .content(asJsonString(admin))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+                .andExpect(status().isOk())
+                .andExpect(content().string("Admin update complete"));
+    }
+
+    /**
+     * This tests if a standard JSON document is fetched with a HTTP Request code status 200
+     * @throws Exception
+     */
+    @Test
+    @WithMockUser(username = "user1", password = "pwd", roles = "USER")
+    public void testFecthAdminInDB() throws Exception {
+
+        List<Admin> adminList = Arrays.asList(
+                new Admin(1,3862349,"John", "Smith", "smith@thu.de", "Neue Str. 23","username2", "password2"),
+                new Admin(1,2131099,"Ann", "Doe", "doe@thu.de", "Neue Str. 8723","username3", "password3"),
+                new Admin(1,27683421,"Jane", "Winter", "winter@thu.de", "Neue Str. 90","username4", "password4")
+        );
+
+        when(adminService.getAdmins()).thenReturn(adminList);
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/admins"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[{}, {}, {}]"));
+    }
+
+    public static String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
+++ b/project/api/thu-excursion/src/test/java/com/thuexcursion/crud/AdminControllerLayerTest.java
@@ -34,17 +34,9 @@ public class AdminControllerLayerTest {
     /**
      * This test is currently disabled since POST requests aren't being done at the moment.
      * 
-     * This tests whether a new Admin can successfully be saved with an HTTP Status 200 (OK).
-     * 
-     * Actual results of the test are 405 Method Not Allowed:
-     * The HyperText Transfer Protocol (HTTP) 405 Method Not Allowed response status code indicates 
-     * that the request method is known by the server but is not supported by the target resource.
-     * The server must generate an Allow header field in a 405 response containing a list of the 
-     * target resource's currently supported methods.
-     * 
+     * This tests whether a new Admin can successfully be saved with an HTTP Status 200 (OK). 
      * @throws Exception
      */
-    @Disabled
     @Test
     @WithMockUser(username = "user1", password = "pwd", roles = "USER")
     public void testSaveAdmin() throws Exception {


### PR DESCRIPTION
# Description
Fixing errors brought up by an accidentally push unit test class AdminControllerLayerTest.java. This error was caused by a missing maven dependancy, spring-boot-security. Furthermore, I added a dependancy for Swagger UI which can ben used to generate API documentation automatically upon compilation of the spring application, however, there is an unknown vulnerability linked to this dependancy which I am still to research on.  

### Errors Addreesed
![Bildschirmfoto 2021-11-16 um 16 28 08](https://user-images.githubusercontent.com/52509544/142014903-55dfe264-e4ad-4ad0-9fdc-12d24be55d3a.png)

### OpenAPI 3 - Swagger UI documentation
![Bildschirmfoto 2021-11-16 um 17 25 04](https://user-images.githubusercontent.com/52509544/142025807-fd13297c-22c4-4901-a355-d6c2e9fcb4b3.png)

![Bildschirmfoto 2021-11-16 um 17 32 55](https://user-images.githubusercontent.com/52509544/142026230-51cc20f3-6037-477f-b9fd-6bcb85362876.png)

Errors list
* Fixes #8 and fixes #9

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
- [x] testSaveAdmin(): Mocks the adding of an admin to the list of admins via POST method using the AdminController and asserts that a response code is OK-200. --ERROR 405 - but it should pass (please test on your machine before merging) 
- [x] testFecthAdminInDB(): Mocks a GET method request for a full list of admins and asserts that a JSON document is returned with a response code OK-200. --PASSED
- [x] curl -X POST "http://localhost:9191/addAdmin" -H  "accept: */*" -H  "Content-Type: application/json" -d "{\"id\":2333,\"employee_no\":78236478,\"name_first\":\"Spring\",\"name_last\":\"Boot\",\"email\":\"boot@spring.com\",\"address\":\"Spring HQ 2\",\"username\":\"userSpring\",\"password\":\"passSpring\"}"  --PASSED (So that means the first testSaveAdmin() unit test should work. Refer to the image below which shows a successful POST request.

![Bildschirmfoto 2021-11-16 um 17 46 05](https://user-images.githubusercontent.com/52509544/142028751-d32109b7-5a27-4932-b568-2d35299d9839.png)

![Bildschirmfoto 2021-11-16 um 17 51 10](https://user-images.githubusercontent.com/52509544/142029296-e3288c58-0e88-41c7-bfe5-8d65c1dc5686.png)

**Test Configuration(if applicable)**:
* Toolchain: Spring-boot-security, MockMVC, Spring-boot-Test
* SDK: n/a

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my change
- [ ] Any dependent changes have been merged and published in downstream modules - Not applicable
