### PR TITLE
fix: error in adding of excursion because of approval_status

### DIFF
--- a/project/api/thu-excursion/src/main/java/com/thuexcursion/crud/model/Excursion.java
+++ b/project/api/thu-excursion/src/main/java/com/thuexcursion/crud/model/Excursion.java
@@ -93,7 +93,7 @@ public class Excursion {
 	@Basic
 	private double excursion_fee;
 
-	@Column(name = "approval_status")
+	@Column(nullable = false,name = "approval_status",insertable = false, updatable = true)
 	@Basic
 	private String approval_status;
 


### PR DESCRIPTION
Fix: an error in adding of excursion occurs because approval_status field in excursion model class lacks properties of Enum.